### PR TITLE
A tree builder without a root node is deprecated

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -12,9 +12,15 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $treeBuilder->root('roromix_spreadsheet');
-
+        $treeBuilder = new TreeBuilder('roromix_spreadsheet');
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $rootNode = $treeBuilder->root('roromix_spreadsheet');
+        }
+        
+        
         return $treeBuilder;
     }
 }


### PR DESCRIPTION
A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0.